### PR TITLE
Insert

### DIFF
--- a/lib/node.rb
+++ b/lib/node.rb
@@ -1,9 +1,21 @@
 class Node
-  def initialize(character = nil) #should default be ""?
+  attr_reader :children,
+              :character
+
+
+  def initialize(character = "") #should default be ""?
     @character = character
     @children = []
     @is_end = false
     @parent = nil
     @weight = 0
   end
+
+  def insert(character)
+    node = Node.new(character)
+    @children << node
+  end
+
+
+
 end

--- a/lib/node.rb
+++ b/lib/node.rb
@@ -1,5 +1,5 @@
 class Node
-  def initialize(character = nil)
+  def initialize(character = nil) #should default be ""?
     @character = character
     @children = []
     @is_end = false

--- a/lib/node.rb
+++ b/lib/node.rb
@@ -15,6 +15,7 @@ class Node
   end
 
   def insert(character, is_end = false) #is_end = false?
+    character = character.upcase
     if children_dont_have_character(character)
       node = Node.new(character, self, is_end)
       @children << node
@@ -41,7 +42,7 @@ class Node
         return child
       end
     end
-    return nil 
+    return nil
   end
 
 

--- a/lib/node.rb
+++ b/lib/node.rb
@@ -12,10 +12,19 @@ class Node
   end
 
   def insert(character) #is_end = false?
-    node = Node.new(character)
-    @children << node
+    if children_dont_have_character(character)
+      node = Node.new(character)
+      @children << node
+    end
   end
 
-
+  def children_dont_have_character(character)
+    @children.each do |child|
+      if child.character == character
+        return false
+      end
+    end
+    return true
+  end
 
 end

--- a/lib/node.rb
+++ b/lib/node.rb
@@ -28,4 +28,10 @@ class Node
     return true
   end
 
+
+
+  # #tells me whther or not a node is an end node
+  # def terminal?
+  #   if self.
+
 end

--- a/lib/node.rb
+++ b/lib/node.rb
@@ -4,17 +4,17 @@ class Node
               :parent
 
 
-  def initialize(character = "") #should default be ""? is_end = false? parent = nil
+  def initialize(character = "", parent = nil) #should default be ""? is_end = false? parent = nil
     @character = character
     @children = []
     @is_end = false
-    @parent = nil
+    @parent = parent
     @weight = 0
   end
 
   def insert(character) #is_end = false?
     if children_dont_have_character(character)
-      node = Node.new(character)
+      node = Node.new(character, self)
       @children << node
     end
   end

--- a/lib/node.rb
+++ b/lib/node.rb
@@ -24,22 +24,27 @@ class Node
   end
 
   def children_dont_have_character(character)
-    @children.each do |child|
-      if child.character == character
-        return false
-      end
+    if find_child_node(character).nil?
+      return true
+    else
+      return false
     end
-    return true
   end
 
   def change_node_is_end(character)
+    find_child_node(character).is_end = true
+  end
+
+  def find_child_node(character)
     @children.each do |child|
       if child.character == character
-
-        child.is_end = true
+        return child
       end
     end
+    return nil 
   end
+
+
 
   # #tells me whther or not a node is an end node
   # def terminal?

--- a/lib/node.rb
+++ b/lib/node.rb
@@ -3,7 +3,7 @@ class Node
               :character
 
 
-  def initialize(character = "") #should default be ""?
+  def initialize(character = "") #should default be ""? is_end = false?
     @character = character
     @children = []
     @is_end = false
@@ -11,7 +11,7 @@ class Node
     @weight = 0
   end
 
-  def insert(character)
+  def insert(character) #is_end = false?
     node = Node.new(character)
     @children << node
   end

--- a/lib/node.rb
+++ b/lib/node.rb
@@ -1,8 +1,9 @@
 class Node
   attr_reader :children,
               :character,
-              :parent,
-              :is_end
+              :parent
+
+  attr_accessor :is_end
 
 
   def initialize(character = "", parent = nil, is_end = false) #should default be ""? is_end = false? parent = nil
@@ -17,6 +18,8 @@ class Node
     if children_dont_have_character(character)
       node = Node.new(character, self, is_end)
       @children << node
+    elsif is_end
+      change_node_is_end(character)
     end
   end
 
@@ -29,7 +32,14 @@ class Node
     return true
   end
 
+  def change_node_is_end(character)
+    @children.each do |child|
+      if child.character == character
 
+        child.is_end = true
+      end
+    end
+  end
 
   # #tells me whther or not a node is an end node
   # def terminal?

--- a/lib/node.rb
+++ b/lib/node.rb
@@ -1,9 +1,10 @@
 class Node
   attr_reader :children,
-              :character
+              :character,
+              :parent
 
 
-  def initialize(character = "") #should default be ""? is_end = false?
+  def initialize(character = "") #should default be ""? is_end = false? parent = nil
     @character = character
     @children = []
     @is_end = false

--- a/lib/node.rb
+++ b/lib/node.rb
@@ -1,20 +1,21 @@
 class Node
   attr_reader :children,
               :character,
-              :parent
+              :parent,
+              :is_end
 
 
-  def initialize(character = "", parent = nil) #should default be ""? is_end = false? parent = nil
+  def initialize(character = "", parent = nil, is_end = false) #should default be ""? is_end = false? parent = nil
     @character = character
     @children = []
-    @is_end = false
+    @is_end = is_end
     @parent = parent
     @weight = 0
   end
 
-  def insert(character) #is_end = false?
+  def insert(character, is_end = false) #is_end = false?
     if children_dont_have_character(character)
-      node = Node.new(character, self)
+      node = Node.new(character, self, is_end)
       @children << node
     end
   end

--- a/test/node_test.rb
+++ b/test/node_test.rb
@@ -63,12 +63,23 @@ class NodeTest < MiniTest::Test
     assert_equal 2, actual
     refute actual > 2
   end
+
   def test_children_can_have_parent
     node = Node.new
     node.insert("A")
     child = node.children[0]
     assert_equal node, child.parent
-  end 
+  end
+  
+  def test_node_can_be_end_of_word
+    node = Node.new
+    node.insert("A")
+    actual = node.children[0].is_end
+    assert_equal false, actual
 
+    node.insert("B", true)
+    actual = node.children[1].is_end
+    assert_equal true, actual
+  end
 
 end

--- a/test/node_test.rb
+++ b/test/node_test.rb
@@ -63,6 +63,12 @@ class NodeTest < MiniTest::Test
     assert_equal 2, actual
     refute actual > 2
   end
+  def test_children_can_have_parent
+    node = Node.new
+    node.insert("A")
+    child = node.children[0]
+    assert_equal node, child.parent
+  end 
 
 
 end

--- a/test/node_test.rb
+++ b/test/node_test.rb
@@ -90,6 +90,14 @@ class NodeTest < MiniTest::Test
     actual = node.children[0].is_end
     assert_equal true, actual
     #true should overwrite duplicated character
+    actual = node.children[1].is_end
+    assert_equal false, actual
+    node.insert("B", true)
+    actual = node.children[1].is_end
+    assert_equal true, actual
+    node.insert("B", false)
+    actual = node.children[1].is_end
+    assert_equal true, actual
   end
 
 end

--- a/test/node_test.rb
+++ b/test/node_test.rb
@@ -11,4 +11,14 @@ class NodeTest < MiniTest::Test
     node = Node.new
     assert_instance_of Node, node
   end#test exist
+
+  def test_it_can_insert
+    node = Node.new
+
+    node.insert("A")
+    actual = node.children[0].character
+    assert_equal "A", actual
+  end
+
+
 end

--- a/test/node_test.rb
+++ b/test/node_test.rb
@@ -16,6 +16,7 @@ class NodeTest < MiniTest::Test
     node = Node.new
 
     node.insert("A")
+    # binding.pry
     actual = node.children[0].character
     assert_equal "A", actual
   end

--- a/test/node_test.rb
+++ b/test/node_test.rb
@@ -19,6 +19,12 @@ class NodeTest < MiniTest::Test
     # binding.pry
     actual = node.children[0].character
     assert_equal "A", actual
+    node.insert("B")
+    actual = node.children[1].character
+    assert_equal "B", actual
+    actual = node.children.count
+    assert_equal 2, actual
+
   end
 
 

--- a/test/node_test.rb
+++ b/test/node_test.rb
@@ -70,7 +70,7 @@ class NodeTest < MiniTest::Test
     child = node.children[0]
     assert_equal node, child.parent
   end
-  
+
   def test_node_can_be_end_of_word
     node = Node.new
     node.insert("A")
@@ -80,6 +80,16 @@ class NodeTest < MiniTest::Test
     node.insert("B", true)
     actual = node.children[1].is_end
     assert_equal true, actual
+  end
+
+  def test_end_of_word_overwrites_duplicate_node
+    node = Node.new
+    node.insert("A")
+    node.insert("B")
+    node.insert("A", true)
+    actual = node.children[0].is_end
+    assert_equal true, actual
+    #true should overwrite duplicated character
   end
 
 end

--- a/test/node_test.rb
+++ b/test/node_test.rb
@@ -27,5 +27,42 @@ class NodeTest < MiniTest::Test
 
   end
 
+  def test_it_does_not_duplicate_characters
+    node = Node.new
+    node.insert("A")
+    actual = node.children[0].character
+    assert_equal "A", actual
+    actual = node.children.count
+    assert_equal 1, actual
+
+    node.insert("A")
+    actual = node.children[0].character
+    assert_equal "A", actual
+    actual = node.children.count
+    assert_equal 1, actual
+    refute actual > 1
+
+    node.insert("B")
+    actual = node.children[1].character
+    assert_equal "B", actual
+    actual = node.children.count
+    assert_equal 2, actual
+    refute actual > 2
+
+    node.insert("B")
+    actual = node.children[1].character
+    assert_equal "B", actual
+    actual = node.children.count
+    assert_equal 2, actual
+    refute actual > 2
+
+    node.insert("A")
+    actual = node.children[0].character
+    assert_equal "A", actual
+    actual = node.children.count
+    assert_equal 2, actual
+    refute actual > 2
+  end
+
 
 end

--- a/test/node_test.rb
+++ b/test/node_test.rb
@@ -100,4 +100,18 @@ class NodeTest < MiniTest::Test
     assert_equal true, actual
   end
 
+  def test_node_insert_is_case_insensitive
+    node = Node.new
+    node.insert("A")
+    node.insert("a")
+    actual = node.children.count
+    assert_equal 1, actual
+    node.insert("b")
+    actual = node.children.count
+    assert_equal 2, actual 
+    node.insert("B")
+    actual = node.children.count
+    assert_equal 2, actual
+  end
+
 end


### PR DESCRIPTION
Node can insert new nodes, which can have unique children without duplicates and know who their parents are. Node insertion is case insensitive. Nodes can be created as the end of a word, or word end can be overwritten. New refactored helper methods are change_node_is_end and find_child_node.